### PR TITLE
fix: remove duplicate 'Change My Mind' entries in memesMeta.js

### DIFF
--- a/src/memesMeta.js
+++ b/src/memesMeta.js
@@ -18,7 +18,7 @@ const memesMeta = {
   "Change My Mind": {
     description: "Man at table with sign",
     keywords: ["table", "sign", "change my mind"],
-    captions: ["Change my mind about coding", "Coffee vs Tea"]
+    captions: ["Change my mind about coding", "Coffee vs Tea", "Coding is life", "Coffee > Tea"]
   },
   "Expanding Brain": {
     description: "Increasingly enlightened brain levels",
@@ -69,11 +69,6 @@ const memesMeta = {
     description: "Man tapping his head",
     keywords: ["thinking", "smart", "plan"],
     captions: ["Can't fail if you don't try", "Use logic"]
-  },
-  "Change My Mind": {
-    description: "Man at table with a sign",
-    keywords: ["table", "sign", "change my mind"],
-    captions: ["Coding is life", "Coffee > Tea"]
   },
   "This Is Fine": {
     description: "Dog sitting in fire saying 'This is fine'",


### PR DESCRIPTION
- Merged two duplicate 'Change My Mind' entries into one entry
- Combined all captions from both entries for better variety:
  * 'Change my mind about coding'
  * 'Coffee vs Tea'
  * 'Coding is life'
  * 'Coffee > Tea'
- Improves code quality and maintainability

This addresses the duplicate key issue that could cause unpredictable behavior when accessing meme metadata through the memesMeta object.

Fixes #137 