### PR TITLE
Fix: Added top padding to Meme History section for better visibility …

### DIFF
--- a/src/components/History.jsx
+++ b/src/components/History.jsx
@@ -58,7 +58,7 @@ const History = () => {
                 color: 'white',
                 minHeight: '60vh'
             }}>
-                <h2>Meme History</h2>
+                <h2 className="history-heading" style={{ color: 'white' }}>Meme History</h2>
                 <p style={{ fontSize: '18px', marginTop: '20px' }}>
                     No memes in history yet. Generate some memes to see them here!
                 </p>
@@ -78,7 +78,7 @@ const History = () => {
                 flexWrap: 'wrap',
                 gap: '10px'
             }}>
-                <h2 style={{ color: 'white', margin: 0 }}>Meme History ({savedMemes.length})</h2>
+                <h2 className="history-heading" style={{ color: 'white' }}>Meme History ({savedMemes.length})</h2>
                 <button
                     onClick={clearHistory}
                     style={{

--- a/src/index.css
+++ b/src/index.css
@@ -106,3 +106,15 @@
 .dynamic-meme-input {
   transition: all 0.25s ease-in-out;
 }
+
+/* History heading spacing to avoid overlap with fixed navbar */
+.history-heading {
+  margin-top: 24px; /* default spacing for small screens */
+}
+
+@media (min-width: 670px) {
+  /* For viewports >= 670px ensure the heading sits below the fixed navbar */
+  .history-heading {
+    margin-top: 80px; /* large enough to clear the navbar and some breathing room */
+  }
+}


### PR DESCRIPTION
## Description
Fixed an issue where the "Meme History" heading was partially hidden under the navbar.
Added appropriate top padding to improve alignment and visibility.

## Issue Reference
Fixes #150 

## Changes Made
- Added top padding/margin in the History section container.

## Screenshot
Before:
<img width="1915" height="250" alt="Screenshot 2025-10-29 192223" src="https://github.com/user-attachments/assets/28bb819c-4cdb-4723-8994-9afe710687f2" />

After:
<img width="1916" height="353" alt="image" src="https://github.com/user-attachments/assets/3a33bf5a-f689-4b4d-96f9-083d8a7c1c83" />


## Type of Change
- [x] Bug fix (UI/UX)

## Additional Context
This PR is part of Hacktoberfest 2025.
